### PR TITLE
Add PR template 

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,67 @@
+# PR title here
+
+| Status  | Type  | Env Vars Change | Review App | Ticket |
+| :---: | :---: | :---: | :--: | :--: |
+| Ready/Hold | Feature/Bug/Tooling/Refactor/Hotfix | Yes/No | [Link](<Review app link here>) | [Link](<ticket link here>) |
+
+> ⚠️ NOTE: use notes like this to emphasize something about the PR. This could include other PRs this PR is built on top of; new or removed environment variables; reasons for why the PR is on hold; or anything else you would like to draw attention to.
+
+## Problem
+
+_What problem are you trying to solve?_
+
+
+## Solution
+
+_How did you solve the problem?_
+
+
+## Before & After Screenshots
+
+**BEFORE**:
+[insert screenshot here]
+
+**AFTER**:
+[insert screenshot here]
+
+
+## Other changes (e.g. bug fixes, UI tweaks, small refactors)
+
+
+## Deploy Notes
+
+_Notes regarding deployment of the contained body of work. These should note any
+new dependencies, new scripts, etc._
+
+**New environment variables**:
+
+- `env var` : env var details
+
+**New scripts**:
+
+- `script` : script details
+
+**New dependencies**:
+
+- `dependency` : dependency details
+
+**New dev dependencies**:
+
+- `dependency` : dependency details
+
+
+## Checklist
+
+<!---
+This checklist is mostly useful as a reminder of small things that can easily be forgotten.
+Put an `x` in all the items that apply, make notes next to any that haven't been addressed,
+Remove any items that are not relevant to this PR.
+-->
+
+General
+
+- [ ] My pull request represents one logical piece of work.
+- [ ] My commits are related to the pull request and look clean.
+- [ ] I have performed a self-review of my code
+- [ ] My code contains no conflicts and is up to date with the latest main branch
+


### PR DESCRIPTION
docs: add default pull-request template

| Status | Type   | Env Vars Change | Review App | Ticket |
| :----: | :----: | :-------------: | :--------: | :----: |
| Ready  | Tooling | No | N/A | #8  |

> ⚠️ **NOTE:** This PR introduces `.github/PULL_REQUEST_TEMPLATE.md`, so all future pull-requests will be pre-populated with a consistent structure.

## Problem
The repo had no standard PR template, leading to inconsistent or incomplete pull-request descriptions and extra back-and-forth during reviews.

## Solution
Added `.github/PULL_REQUEST_TEMPLATE.md` containing sections for status, problem/solution, testing steps, deploy notes, and a review checklist.

## Before & After Screenshots

**BEFORE**  
_No default text when opening a new PR._

**AFTER**  
PR body now auto-fills with the new template.

## Other changes
None.

## Deploy Notes
No migrations, scripts, or environment-variable changes required.

## Checklist
General
- [x] My pull request represents one logical piece of work.
- [x] My commits are related to the pull request and look clean.
- [x] I have performed a self-review of my code.
- [x] My code contains no conflicts and is up-to-date with the latest `main`.
